### PR TITLE
Guardfile template changes for step_definitions

### DIFF
--- a/lib/guard/cucumber/templates/Guardfile
+++ b/lib/guard/cucumber/templates/Guardfile
@@ -1,5 +1,5 @@
 guard 'cucumber' do
   watch(%r{features/.+\.feature})
   watch(%r{features/support/.+})          { 'features' }
-  watch(%r{features/step_definitions/.+}) { 'features' }
+  watch(%r{features/step_definitions/(.+)_steps\.rb}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }
 end


### PR DESCRIPTION
Hey... great work on this library!  I changed the Guardfile template to run only 'matching' features when a step_definition is updated.  If there is no match, it runs all the features.  This change should be helpful to anyone with a large/slow feature-set.

Cheers!
Chip
