### PR TITLE
Allow the user to specify a prefix to the cucumber command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Former `:color`, `:drb`, `:port` and `:profile` options are thus deprecated and 
 :change_format => 'pretty'        # Use a different cucumber format when running individual features
                                   # This replaces the Cucumber --format option within the :cli option
                                   # default: nil
+
+:command_prefix => 'xvfb-run'     # Add a prefix to the cucumber command such as 'xvfb-run' or any 
+                                  # other shell script. 
+                                  # The example generates: 'xvfb-run bundle exec cucumber ...'
+                                  # default: nil
 ```
 
 ## Cucumber configuration

--- a/lib/guard/cucumber/runner.rb
+++ b/lib/guard/cucumber/runner.rb
@@ -33,10 +33,12 @@ module Guard
         # @option options [Boolean] :bundler use bundler or not
         # @option options [Array<String>] :rvm a list of rvm version to use for the test
         # @option options [Boolean] :notification show notifications
+        # @option options [Boolean] :command_prefix allows adding an additional prefix to the cucumber command. Ideal for running xvfb-run for terminal only cucumber tests.
         # @return [String] the Cucumber command
         #
         def cucumber_command(paths, options)
           cmd = []
+          cmd << options[:command_prefix] if options[:command_prefix]
           cmd << "rvm #{options[:rvm].join(',')} exec" if options[:rvm].is_a?(Array)
           cmd << 'bundle exec' if (bundler? && options[:bundler] != false) || (bundler? && options[:binstubs].is_a?(TrueClass))
           cmd << cucumber_exec(options)

--- a/spec/guard/cucumber/runner_spec.rb
+++ b/spec/guard/cucumber/runner_spec.rb
@@ -20,6 +20,15 @@ describe Guard::Cucumber::Runner do
       end
     end
 
+    context 'with a :command_prefix option' do
+      it 'executes cucumber with the command_prefix option' do
+        runner.should_receive(:system).with(
+            "xvfb-run bundle exec cucumber --require #{ @lib_path.join('guard/cucumber/notification_formatter.rb') } --format Guard::Cucumber::NotificationFormatter --out #{ null_device } --require features features"
+        )
+        runner.run(['features'], { :command_prefix => "xvfb-run" })
+      end
+    end
+
     context 'with a :bundler option' do
       it 'runs without bundler when false' do
         runner.should_receive(:system).with(


### PR DESCRIPTION
The command_prefix option allows you to prepend any other shell script
to your cucumber execution. For example, for terminal only cucumber
tests you may need to run xvfb-run before the cucumber command. The
command prefix option will allow you to do that.
