### PR TITLE
Fix contributors link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ and follow [@netzpirat](https://twitter.com/#!/netzpirat) on Twitter for project
 
 ## Contributors
 
-See the GitHub list of [contributors](https://github.com/netzpirat/guard-jasmine/contributors).
+See the GitHub list of [contributors](https://github.com/netzpirat/guard-cucumber/contributors).
 
 Since guard-cucumber is very close to guard-rspec, some contributions by the following authors have been
 incorporated into guard-cucumber:


### PR DESCRIPTION
I wanted to add a wiki page to document using a callback to get cucumber to run after rspec but looks like I need to be a contributor.  Then I found the link to the contributors was wrong, so this fixes it.  If you accept it, then I can add that wiki page :)
