### PR TITLE
scan_for_focus_path should return an empty array if path is a directory

### DIFF
--- a/lib/guard/cucumber/focuser.rb
+++ b/lib/guard/cucumber/focuser.rb
@@ -44,6 +44,7 @@ module Guard
         end
 
         # Checks to see if the file at path contains the focus tag
+        # It will return an empty array if the path is a directory.
         #
         # @param [String] path the file path to search
         # @param [String] focus_tag the focus tag to look for in each path
@@ -51,6 +52,8 @@ module Guard
         #
         def scan_path_for_focus_tag(path, focus_tag)
           line_numbers = []
+
+          return line_numbers if File.directory?(path)
 
           File.open(path, 'r') do |f|
             while (line = f.gets)

--- a/spec/guard/cucumber/focuser_spec.rb
+++ b/spec/guard/cucumber/focuser_spec.rb
@@ -104,6 +104,17 @@ describe Guard::Cucumber::Focuser do
         focuser.scan_path_for_focus_tag(path, focus_tag).should eql([])
       end
     end
+
+    context 'file that is a directory' do
+      before do
+        File.should_receive(:directory?).with(dir).and_return(true)
+      end
+
+      it 'returns an empty array' do
+        focuser.scan_path_for_focus_tag(dir, focus_tag).should eql([])
+      end
+    end
+
   end
 
   describe '#append_line_numbers_to_path' do


### PR DESCRIPTION
![Screen Shot 2013-01-04 at 1 52 46 PM](https://f.cloud.github.com/assets/420959/44050/7910b646-56a8-11e2-9fcb-1d00b76161b4.png)

When I have set the `focus_on` option, and I run all feature tests in cucumber-guard, then a directory path may be sent to `Focuser#scan_for_focus_path`. This method tries to call `File#gets` on the directory, and ruby throws a "`Is a directory`" error.

This patch simply returns an empty array if the file is a directory.
