### PR TITLE
prevent autoload from interfering with namespace

### DIFF
--- a/lib/guard/cucumber.rb
+++ b/lib/guard/cucumber.rb
@@ -2,15 +2,15 @@ require "guard"
 require "guard/plugin"
 require "cucumber"
 require "guard/cucumber/version"
+require "guard/cucumber/runner"
+require "guard/cucumber/inspector"
+require "guard/cucumber/focuser"
 
 module Guard
   # The Cucumber guard that gets notifications about the following
   # Guard events: `start`, `stop`, `reload`, `run_all` and `run_on_change`.
   #
   class Cucumber < Plugin
-    autoload :Runner, "guard/cucumber/runner"
-    autoload :Inspector, "guard/cucumber/inspector"
-    autoload :Focuser, "guard/cucumber/focuser"
 
     attr_accessor :last_failed, :failed_path
 

--- a/lib/guard/cucumber/focuser.rb
+++ b/lib/guard/cucumber/focuser.rb
@@ -1,5 +1,5 @@
 module Guard
-  class Cucumber
+  class Cucumber < Plugin
     # The Cucumber focuser updates cucumber feature paths to
     # focus on sections tagged with a provided focus_tag.
     #

--- a/lib/guard/cucumber/inspector.rb
+++ b/lib/guard/cucumber/inspector.rb
@@ -1,5 +1,5 @@
 module Guard
-  class Cucumber
+  class Cucumber < Plugin
     # The inspector verifies of the changed paths are valid
     # for Guard::Cucumber.
     #

--- a/lib/guard/cucumber/notification_formatter.rb
+++ b/lib/guard/cucumber/notification_formatter.rb
@@ -4,7 +4,7 @@ require "cucumber/formatter/console"
 require "cucumber/formatter/io"
 
 module Guard
-  class Cucumber
+  class Cucumber < Plugin
     # The notification formatter is a Cucumber formatter that Guard::Cucumber
     # passes to the Cucumber binary. It writes the `rerun.txt` file with the
     # failed features

--- a/lib/guard/cucumber/runner.rb
+++ b/lib/guard/cucumber/runner.rb
@@ -1,5 +1,5 @@
 module Guard
-  class Cucumber
+  class Cucumber < Plugin
     # The Cucumber runner handles the execution of the cucumber binary.
     #
     module Runner


### PR DESCRIPTION
I had issues with Guard::Cucumber.new(options) failing due to "ArgumentError - initialize takes 0 arguments, 1 given". The problem went away with this fix.
