### PR TITLE
Fixed travis link for guard/guard-cucumber repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Guard::Cucumber [![Build Status](https://secure.travis-ci.org/netzpirat/guard-cucumber.png)](http://travis-ci.org/netzpirat/guard-cucumber)
+# Guard::Cucumber [![Build Status](https://secure.travis-ci.org/guard/guard-cucumber.png)](http://travis-ci.org/netzpirat/guard-cucumber)
 
 Guard::Cucumber allows you to automatically run Cucumber features when files are modified.
 


### PR DESCRIPTION
The README Travis build button was still pointing at `netzpirat/guard-cucumber`
