### PR TITLE
Parameterize "rerun.txt" on $RERUN_TXT

### DIFF
--- a/lib/guard/cucumber/notification_formatter.rb
+++ b/lib/guard/cucumber/notification_formatter.rb
@@ -115,7 +115,7 @@ module Guard
       # Writes the `rerun.txt` file containing all failed features.
       #
       def write_rerun_features
-        File.open("rerun.txt", "w") do |f|
+        File.open(ENV["RERUN_TXT"] || "rerun.txt", "w") do |f|
           f.puts @file_names.join(" ")
         end
       end


### PR DESCRIPTION
Especially when running in a read-only filesystem, one needs to be able to configure the file name used for the `rerun.txt` file.