### PR TITLE
Drop support for obsolete Ruby versions (< 2.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: ruby
 bundler_args: --without development
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
-  - jruby-19mode
+  - 2.2.0
+  - 2.3.1
+  - jruby-9.0.5.0
   - rbx
+  - ruby-head
 matrix:
   allow_failures:
     - rvm: rbx
+    - rvm: ruby-head
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Guard::Cucumber allows you to automatically run Cucumber features when files are modified.
 
-Tested on MRI Ruby 1.9.3, 2.0.0, 2.1.0 and the latest versions of JRuby.
+Supported Ruby versions are those tested on [Travis CI](https://travis-ci.org/guard/guard-cucumber).
+(NOTE: Any Ruby version earlier than 2.2.5 is outdated and likely insecure).
+
 
 If you have any questions please join us on our [Google group](http://groups.google.com/group/guard-dev) or on `#guard` (irc.freenode.net).
 


### PR DESCRIPTION
- most outdated Ruby versions have security issues
- all outdated Ruby version have lots of unfixed bugs