### PR TITLE
fix option default, docs and Guardfile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ all_on_start: false               # Don't run all the features at startup
 keep_failed: false                # Keep failed features until they pass
                                   # default: true
 
-run_all: {cmd: "-p"}              # Override any option when running all specs
+run_all: {cmd_additional_args: "--format pretty"}              # Override any option when running all specs
                                   # default: {}
 
 focus_on: 'dev'                   # Focus on scenarios tagged with '@dev'

--- a/lib/guard/cucumber.rb
+++ b/lib/guard/cucumber.rb
@@ -49,7 +49,8 @@ module Guard
         all_after_pass: true,
         all_on_start: true,
         keep_failed: true,
-        cmd_additional_args: "",
+        cmd: "cucumber",
+        cmd_additional_args: "--no-profile --color --format progress --strict",
         feature_sets: ["features"]
       }.update(options)
 

--- a/lib/guard/cucumber/templates/Guardfile
+++ b/lib/guard/cucumber/templates/Guardfile
@@ -1,4 +1,20 @@
-guard "cucumber" do
+cucumber_options = {
+  # Below are examples overriding defaults
+
+  # cmd: 'bin/cucumber',
+  # cmd_additional_args: '--profile guard',
+
+  # all_after_pass: false,
+  # all_on_start: false,
+  # keep_failed: false,
+  # feature_sets: ['features/frontend', 'features/experimental'],
+
+  # run_all: { cmd_additional_args: '--profile guard_all' },
+  # focus_on: { 'wip' }, # @wip
+  # notification: false
+}
+
+guard "cucumber", cucumber_options do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$}) { "features" }
 

--- a/spec/guard/cucumber_spec.rb
+++ b/spec/guard/cucumber_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Guard::Cucumber do
       all_after_pass: true,
       all_on_start: true,
       keep_failed: true,
-      cmd_additional_args: "",
+      cmd: "cucumber",
+      cmd_additional_args: "--no-profile --color --format progress --strict",
       feature_sets: ["features"]
     }
   end
@@ -41,7 +42,7 @@ RSpec.describe Guard::Cucumber do
 
       it "sets a default :cmd_additional_args option" do
         expect(subject.options[:cmd_additional_args]).
-          to eql ""
+          to eql "--no-profile --color --format progress --strict"
       end
 
       it "sets a default :feature_sets option" do


### PR DESCRIPTION
- conveniently attach sample options (template)
- fix README option example
- make default options match README.md