### PR TITLE
Feature: Cucumber 3.x Support

### DIFF
--- a/guard-cucumber.gemspec
+++ b/guard-cucumber.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "guard-compat",       "~> 1.0"
   s.add_dependency "cucumber",    "~> 3.1"
   s.add_dependency "nenv", "~> 0.1"
 
+  s.add_development_dependency "guard-compat", "~> 1.0"
   s.add_development_dependency "bundler", "~> 1.6"
 
   s.files = `git ls-files -z`.split("\x0").select do |f|

--- a/guard-cucumber.gemspec
+++ b/guard-cucumber.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "cucumber",    "~> 3.1"
-  s.add_dependency "nenv", "~> 0.1"
+  s.add_dependency "cucumber", ">= 3.1"
+  s.add_dependency "nenv", ">= 0.1"
 
-  s.add_development_dependency "guard-compat", "~> 1.0"
-  s.add_development_dependency "bundler", "~> 1.6"
+  s.add_development_dependency "guard-compat", ">= 1.0"
+  s.add_development_dependency "bundler", ">= 1.6"
 
   s.files = `git ls-files -z`.split("\x0").select do |f|
     /^lib\// =~ f

--- a/guard-cucumber.gemspec
+++ b/guard-cucumber.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "guard-compat",       "~> 1.0"
-  s.add_dependency "cucumber",    "~> 2.0"
+  s.add_dependency "cucumber",    "~> 3.1"
   s.add_dependency "nenv", "~> 0.1"
 
   s.add_development_dependency "bundler", "~> 1.6"

--- a/lib/guard/cucumber/notification_formatter.rb
+++ b/lib/guard/cucumber/notification_formatter.rb
@@ -145,6 +145,10 @@ module Guard
         end
       end
 
+      def dump_count(count, what, state = nil)
+        [count, state, "#{what}#{count == 1 ? '' : 's'}"].compact.join(' ')
+      end
+
       def status_to_message(status)
         len = step_mother.steps(status).length
         dump_count(len, "step", status.to_s)


### PR DESCRIPTION
This is a minimalist pull-request that:

1. bumps the minimum Cucumber version to 3.1
1. replicates the missing dump_count method from the cucumber-ruby source code
1. passes all existing specs

This appears to close #36 and stops the NoMethodError exception raised from Guard::Cucumber::NotificationFormatter.