### PR TITLE
close #39

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 #
 group :development do
   gem "guard-rspec", require: false
-  gem "guard-bundler", "~> 2.0.0", require: false
+  gem "guard-bundler", require: false
   gem "yard", require: false
   gem "redcarpet", require: false
   gem "guard-rubocop", require: false

--- a/guard-cucumber.gemspec
+++ b/guard-cucumber.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "cucumber", ">= 3.1"
+  s.add_dependency "guard-compat", ">= 1.0"
   s.add_dependency "nenv", ">= 0.1"
 
-  s.add_development_dependency "guard-compat", ">= 1.0"
   s.add_development_dependency "bundler", ">= 1.6"
 
   s.files = `git ls-files -z`.split("\x0").select do |f|

--- a/guard-cucumber.gemspec
+++ b/guard-cucumber.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "cucumber", ">= 3.1"
+  s.add_dependency "cucumber", ">= 3.1", "< 4.0"
   s.add_dependency "guard-compat", ">= 1.0"
   s.add_dependency "nenv", ">= 0.1"
 

--- a/lib/guard/cucumber/notification_formatter.rb
+++ b/lib/guard/cucumber/notification_formatter.rb
@@ -146,7 +146,7 @@ module Guard
       end
 
       def dump_count(count, what, state = nil)
-        [count, state, "#{what}#{count == 1 ? '' : 's'}"].compact.join(' ')
+        [count, state, "#{what}#{count == 1 ? '' : 's'}"].compact.join(" ")
       end
 
       def status_to_message(status)

--- a/lib/guard/cucumber/version.rb
+++ b/lib/guard/cucumber/version.rb
@@ -1,6 +1,6 @@
 module Guard
   module CucumberVersion
     # Guard::Cucumber version that is used for the Gem specification
-    VERSION = "3.0.0".freeze
+    VERSION = "3.0.1".freeze
   end
 end


### PR DESCRIPTION
1. d88026e unconstrain guard-bundler version
1. acba86f move guard-compat to runtime dependency
1. 8ea72b1 constrain cucumber (> 3.1, < 4.0)
1. 9993179 feed rubocop
1. bd8e5d9 bump guard-cucumber to 3.0.1