### PR TITLE
Bugfix/42 initialising guard cucumber plugin fails with error

### DIFF
--- a/guard-cucumber.gemspec
+++ b/guard-cucumber.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "cucumber", ">= 3.1"
   s.add_dependency "nenv", ">= 0.1"
+  s.add_dependency "guard-compat", ">= 1.0"
 
-  s.add_development_dependency "guard-compat", ">= 1.0"
   s.add_development_dependency "bundler", ">= 1.6"
 
   s.files = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
Not sure if reverting the commit 4c7d0e4a99c24526fc78bd455514c6d3614ef0fd is a good idea. See the discussion in #42.